### PR TITLE
add logging

### DIFF
--- a/Chefster.csproj
+++ b/Chefster.csproj
@@ -35,6 +35,7 @@
       </PackageReference>
       <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.10.0" />
       <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
+      <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
       <PackageReference Include="xunit" Version="2.8.1" />

--- a/Common/LogLevelsEnum.cs
+++ b/Common/LogLevelsEnum.cs
@@ -1,0 +1,9 @@
+namespace Chefster.Common;
+
+public enum LogLevels
+{
+    Info = 0,
+    Warning = 1,
+    Error = 2,
+    Unknown = 3
+}

--- a/Models/LogModel.cs
+++ b/Models/LogModel.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+using Chefster.Common;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Chefster.Models;
+
+public class LogModel
+{
+    [BsonId]
+    [JsonIgnore]
+    public ObjectId Id { get; set; }
+    public required LogLevels LogLevel { get; set; }
+    public required string Message { get; set; }
+    public string? Source { get; set; }
+    public string? CreatedAt { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Auth0.AspNetCore.Authentication;
 using Chefster.Context;
+using Chefster.Models;
 using Chefster.Services;
 using Hangfire;
 using Hangfire.Mongo;
@@ -56,6 +57,22 @@ builder.Services.AddDbContext<ChefsterDbContext>(options =>
     }
 });
 
+builder.Services.AddSingleton<IMongoClient, MongoClient>(sp => new MongoClient(
+    builder.Configuration["MONGO_LOG_CONN"]
+));
+
+builder.Services.AddScoped(sp =>
+{
+    var client = sp.GetRequiredService<IMongoClient>();
+    return client.GetDatabase("chefster-logs");
+});
+
+builder.Services.AddScoped(sp =>
+{
+    var database = sp.GetRequiredService<IMongoDatabase>();
+    return database.GetCollection<LogModel>("logs");
+});
+
 // add services
 builder.Services.AddScoped<FamilyService>();
 builder.Services.AddScoped<MemberService>();
@@ -67,6 +84,7 @@ builder.Services.AddScoped<ViewToStringService>();
 builder.Services.AddScoped<PreviousRecipesService>();
 builder.Services.AddScoped<UpdateProfileService>();
 builder.Services.AddScoped<LetterQueueService>();
+builder.Services.AddScoped<LoggingService>();
 builder.Services.AddControllers();
 builder.Services.AddControllersWithViews();
 

--- a/Services/LoggingService.cs
+++ b/Services/LoggingService.cs
@@ -1,0 +1,51 @@
+using Chefster.Common;
+using Chefster.Interfaces;
+using Chefster.Models;
+using MongoDB.Driver;
+
+namespace Chefster.Services;
+
+/*
+    Logging service that is used just for the Web App.
+    Not accessible via an API
+*/
+
+public interface ILog
+{
+    public void Log(string message, LogLevels loglevel, string? source = null);
+}
+
+public class LoggingService(IMongoClient mongoClient) : ILog
+{
+    private readonly IMongoClient _mongoClient = mongoClient;
+
+    public void Log(string message, LogLevels loglevel, string? source = null)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            Console.WriteLine("Message cannot be empty!");
+            return;
+        }
+
+        var database = _mongoClient.GetDatabase("chefster-logs");
+        // if it doesn't exit it will create it
+        var collection = database.GetCollection<LogModel>("logs");
+
+        var log = new LogModel
+        {
+            Message = message,
+            LogLevel = loglevel,
+            Source = source,
+            CreatedAt = DateTime.UtcNow.ToString()
+        };
+
+        try
+        {
+            collection.InsertOne(log);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"Failed to save log: {e}");
+        }
+    }
+}

--- a/Tests/DatabaseFixture.cs
+++ b/Tests/DatabaseFixture.cs
@@ -12,6 +12,7 @@ public class DatabaseFixture
     public FamilyService FamilyService { get; private set; }
     public MemberService MemberService { get; private set; }
     public ConsiderationsService ConsiderationsService { get; private set; }
+    public LoggingService? LoggingService { get; private set; }
 
     public DatabaseFixture()
     {
@@ -21,7 +22,7 @@ public class DatabaseFixture
 
         Context = new ChefsterDbContext(options);
 
-        FamilyService = new FamilyService(Context);
+        FamilyService = new FamilyService(Context, LoggingService!);
         MemberService = new MemberService(Context);
         ConsiderationsService = new ConsiderationsService(Context);
     }

--- a/Tests/DatabaseFixture.cs
+++ b/Tests/DatabaseFixture.cs
@@ -3,6 +3,8 @@ using Chefster.Context;
 using Chefster.Models;
 using Chefster.Services;
 using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+using Moq;
 
 namespace Chefster.Tests;
 
@@ -12,7 +14,7 @@ public class DatabaseFixture
     public FamilyService FamilyService { get; private set; }
     public MemberService MemberService { get; private set; }
     public ConsiderationsService ConsiderationsService { get; private set; }
-    public LoggingService? LoggingService { get; private set; }
+    public required LoggingService LoggingService { get; set; }
 
     public DatabaseFixture()
     {
@@ -22,7 +24,24 @@ public class DatabaseFixture
 
         Context = new ChefsterDbContext(options);
 
-        FamilyService = new FamilyService(Context, LoggingService!);
+        // Mock MongoClient for LoggingService
+        // prevents us from having to use a real mongo connection
+        var mockMongoClient = new Mock<IMongoClient>();
+        var mockDatabase = new Mock<IMongoDatabase>();
+        var mockCollection = new Mock<IMongoCollection<LogModel>>();
+
+        // define what the mockMongoClient and mockDatabase is going to return
+        mockMongoClient
+            .Setup(c => c.GetDatabase(It.IsAny<string>(), null))
+            .Returns(mockDatabase.Object);
+
+        mockDatabase
+            .Setup(db => db.GetCollection<LogModel>(It.IsAny<string>(), null))
+            .Returns(mockCollection.Object);
+
+        // Pass mock MongoClient to LoggingService
+        LoggingService = new LoggingService(mockMongoClient.Object);
+        FamilyService = new FamilyService(Context, LoggingService);
         MemberService = new MemberService(Context);
         ConsiderationsService = new ConsiderationsService(Context);
     }
@@ -51,7 +70,7 @@ public class DatabaseFixture
                 Id = "4",
                 CreatedAt = DateTime.Now,
                 Email = "test4@email.com",
-                UserStatus = UserStatus.Unknown,
+                UserStatus = UserStatus.FreeTrial,
                 FamilySize = 8,
                 GenerationDay = DayOfWeek.Monday,
                 GenerationTime = new TimeSpan(19000),

--- a/Tests/FamilyServiceTests.cs
+++ b/Tests/FamilyServiceTests.cs
@@ -27,7 +27,6 @@ public class FamilyServiceTests(DatabaseFixture fixture) : IClassFixture<Databas
     [Fact]
     public void CreateFamily_SavesFamilyToDatabase()
     {
-        _fixture.Initialize();
         var familyToAdd = new FamilyModel
         {
             Id = "2",
@@ -66,23 +65,6 @@ public class FamilyServiceTests(DatabaseFixture fixture) : IClassFixture<Databas
     public void UpdateFamily_UpdatesFamilyInDatabase()
     {
         _fixture.Initialize();
-        var familyToUpdate = new FamilyModel
-        {
-            Id = "3",
-            CreatedAt = DateTime.Now,
-            Email = "test3@email.com",
-            UserStatus = UserStatus.ExtendedFreeTrial,
-            FamilySize = 4,
-            NumberOfBreakfastMeals = 0,
-            NumberOfLunchMeals = 0,
-            NumberOfDinnerMeals = 7,
-            GenerationDay = DayOfWeek.Wednesday,
-            GenerationTime = new TimeSpan(1000),
-            TimeZone = "America/Chicago",
-            PhoneNumber = "9998887777"
-        };
-
-        _fixture.FamilyService.CreateFamily(familyToUpdate);
 
         var updated = new FamilyUpdateDto
         {
@@ -96,15 +78,15 @@ public class FamilyServiceTests(DatabaseFixture fixture) : IClassFixture<Databas
             TimeZone = "merica"
         };
 
-        _fixture.FamilyService.UpdateFamily("3", updated);
+        _fixture.FamilyService.UpdateFamily("1", updated);
 
         // family doesnt exist case
         var failed = _fixture.FamilyService.UpdateFamily("doesntExist", updated);
         Assert.False(failed.Success);
 
-        var family = _fixture.FamilyService.GetById("3");
+        var family = _fixture.FamilyService.GetById("1");
         Assert.NotNull(family.Data);
-        Assert.Equal("test3@email.com", family.Data.Email);
+        Assert.Equal("test@email.com", family.Data.Email);
         Assert.Equal(10, family.Data.FamilySize);
         Assert.Equal(2, family.Data.NumberOfBreakfastMeals);
         Assert.Equal(2, family.Data.NumberOfLunchMeals);


### PR DESCRIPTION
This PR adds a logging service that can be injected into any other service. The logs are generic and contain 4 attributes, Message, logLevel, and source, and CreatedAt. All logs are stored within a database called `chefster-logs` in a collections called `logs`. 